### PR TITLE
Add asset cache busting

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -17,9 +17,9 @@
     <title>Allmon3</title>
 
 	<!-- CSS -->
-	<link href="css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
-    <link href="css/main.css" rel="stylesheet">
-    <link href="css/custom.css" rel="stylesheet">
+	<link href="css/bootstrap.min.css?v=@@HEAD-DEVELOP@@" rel="stylesheet" crossorigin="anonymous">
+    <link href="css/main.css?v=@@HEAD-DEVELOP@@" rel="stylesheet">
+    <link href="css/custom.css?v=@@HEAD-DEVELOP@@" rel="stylesheet">
 
     <!-- Favicons -->
 	<link rel="apple-touch-icon" href="img/favicons/favicon-180x180.png" type="image/png" sizes="180x180">

--- a/web/voter.html
+++ b/web/voter.html
@@ -17,9 +17,9 @@
     <title>Allmon3 Voter</title>
 
 	<!-- CSS -->
-	<link href="css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
-    <link href="css/main.css" rel="stylesheet">
-    <link href="css/custom.css" rel="stylesheet">
+	<link href="css/bootstrap.min.css?v=@@HEAD-DEVELOP@@" rel="stylesheet" crossorigin="anonymous">
+    <link href="css/main.css?v=@@HEAD-DEVELOP@@" rel="stylesheet">
+    <link href="css/custom.css?v=@@HEAD-DEVELOP@@" rel="stylesheet">
 
     <!-- Favicons -->
 	<link rel="apple-touch-icon" href="img/favicons/favicon-180x180.png" type="image/png" sizes="180x180">


### PR DESCRIPTION
New versions require a hard browser refresh to get new asset versions, I couldnt work out why I was not seeing the new custom tx/rx colours from custom.css

This PR adds the current version number to asset urls like `<link href="css/custom.css?v=1.2.0" rel="stylesheet">` via the Makefile `verset` function.