### PR TITLE
Raspbian 10 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,12 @@ dpkg -i allmon3_1.2.0-1.bullseye_all.deb
 ```
 gpg --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC
 gpg --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138
+gpg --keyserver keyserver.ubuntu.com --recv-keys 0E98404D386FA1D9
+gpg --keyserver keyserver.ubuntu.com --recv-keys 6ED0E7B82643E131
 gpg --export 04EE7237B7D453EC | sudo apt-key add -
 gpg --export 648ACFD622F3D138 | sudo apt-key add -
+gpg --export 0E98404D386FA1D9 | sudo apt-key add -
+gpg --export 6ED0E7B82643E131 | sudo apt-key add -
 echo "deb https://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/buster-backports.list
 apt update
 ```

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ apt update
 2. Install the dependendencies
 ```
 apt install -y apache2 python3-argon2 
-apt install -y -t buster-backports python3-async-timeout python3-attr python3-multidict python3-yarl
+apt install -y -t buster-backports python3-async-timeout python3-attr python3-multidict python3-yarl python-pip3
 ```
 
 3. Install Python modules using PIP3


### PR DESCRIPTION
I did not test if the added keys replace those provided in the README.md.  This was the error I encountered:

Following the instructions for importing keys on Raspbian 10 (built from AllStar Link Live) and then running `apt update` results in:

``` console
W: GPG error: https://deb.debian.org/debian buster-backports InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 0E98404D386FA1D9 NO_PUBKEY 6ED0E7B82643E131
E: The repository 'https://deb.debian.org/debian buster-backports InRelease' is not signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```

I also added `python3-pip` to the package installation command.

After that Allmon3 appears to be working perfectly on ASL-Live-Build of Raspbian 10.
