### PR TITLE
Allow external links in sidebar to open in new tab

### DIFF
--- a/conf/web.ini
+++ b/conf/web.ini
@@ -21,6 +21,12 @@ CONFIG_HEADER_TITLE = Allmon3 Monitoring Dashboard
 ; file is relative to the img/ subdirectory of Allmon3
 CONFIG_HEADER_LOGO = ""
 
+; CONFIG_MENU_SINGLE_TARGET sets the target for single menu links
+; in the sidebar menus.
+; Default will open external links in same window
+; _blank will open external links in a new tab
+;CONFIG_MENU_SINGLE_TARGET = _blank
+
 ; Location of the password table
 ;USERS_TABLE_LOCATION = /etc/allmon3/users
 

--- a/src/asl_allmon/allmon3_server/__init__.py
+++ b/src/asl_allmon/allmon3_server/__init__.py
@@ -208,6 +208,7 @@ class ServerWS:
         ui_html.update({ "HEADER_TITLE" : self.config_web.header_title })
         ui_html.update({ "HEADER_LOGO" : self.config_web.header_logo })
         ui_html.update({ "HOME_BUTTON_URL" : self.config_web.home_loc })
+        ui_html.update({ "CONFIG_MENU_SINGLE_TARGET" : self.config_web.menu_target })
         return json.dumps(ui_html)
 
     ##

--- a/src/asl_allmon/web_configs/__init__.py
+++ b/src/asl_allmon/web_configs/__init__.py
@@ -30,6 +30,11 @@ class WebConfigs:
         else:
             self.header_logo = None
 
+        if "CONFIG_MENU_SINGLE_TARGET" in config["web"]:
+           self.menu_target = config["web"]["CONFIG_MENU_SINGLE_TARGET"]
+        else:
+           self.menu_target = ""
+
         if "USERS_TABLE_LOCATION" in config["web"]:
             self.user_table = re.sub(r'[\'\"]', '', config["web"]["USERS_TABLE_LOCATION"])
         else:

--- a/web/js/functions.js
+++ b/web/js/functions.js
@@ -188,6 +188,7 @@ async function createSidebarMenu(){
 	const pageName = "index.html";
 
 	let customMenu = await getAPIJSON("master/ui/custom/menu");
+  let customElements = await getAPIJSON("master/ui/custom/html");
 	if(Object.keys(customMenu).length > 0){
 		for(let majMenu of Object.keys(customMenu)){
 			let majMenuObj = customMenu[majMenu];
@@ -225,7 +226,8 @@ async function createSidebarMenu(){
 									if( currp === newp ){
 										onClickSlot = "onclick=\"window.location.reload()\"";
 									}
-									navMenu = navMenu.concat(`<a class="dropdown-item" href="${newp}" ${onClickSlot}">${ml}</a>`);
+                  target = 'target="' + customElements.CONFIG_MENU_SINGLE_TARGET +'"';
+									navMenu = navMenu.concat(`<a class="dropdown-item" href="${newp}" ${onClickSlot} ${target}">${ml}</a>`);
 								}
 							}
 						} else {
@@ -236,8 +238,9 @@ async function createSidebarMenu(){
 								if( currp === newp ){
 									onClickSlot = "onclick=\"window.location.reload()\"";
 								}
+                target = 'target="' + customElements.CONFIG_MENU_SINGLE_TARGET +'"';
 								navMenu = navMenu.concat(`<div class="btn-group">
-									<a href="${newp}" ${onClickSlot} class="btn btn-secondary" role="button">${ml}</a>
+                  <a href="${newp}" ${onClickSlot} ${target} class="btn btn-secondary" role="button">${ml}</a>
 									</div>`);
 							}
 						}


### PR DESCRIPTION
Adds a new config variable in web.ini
`CONFIG_MENU_SINGLE_TARGET`
Default is unset.

If changed to `_blank` then all external links in the created sidebar will use that target and open in a new tab

Fixes #303