### PR TITLE
Add links for missing (existing) favicon files

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -27,6 +27,8 @@
 	<link rel="apple-touch-icon" href="img/favicons/favicon-180x180.png" type="image/png" sizes="180x180">
 	<link rel="icon" href="img/favicons/favicon-32x32.png" sizes="32x32" type="image/png">
 	<link rel="icon" href="img/favicons/favicon-16x16.png" sizes="16x16" type="image/png">
+	<link rel="icon" href="img/favicons/favicon-192x192.png" sizes="192x192" type="image/png">
+	<link rel="icon" href="img/favicons/favicon-512x512.png" sizes="512x512" type="image/png">
 	<link rel="icon" href="img/favicons/favicon.ico" type="image/png">
 
 </head>

--- a/web/voter.html
+++ b/web/voter.html
@@ -28,6 +28,8 @@
 	<link rel="apple-touch-icon" href="img/favicons/favicon-180x180.png" type="image/png" sizes="180x180">
 	<link rel="icon" href="img/favicons/favicon-32x32.png" sizes="32x32" type="image/png">
 	<link rel="icon" href="img/favicons/favicon-16x16.png" sizes="16x16" type="image/png">
+	<link rel="icon" href="img/favicons/favicon-192x192.png" sizes="192x192" type="image/png">
+	<link rel="icon" href="img/favicons/favicon-512x512.png" sizes="512x512" type="image/png">
 	<link rel="icon" href="img/favicons/favicon.ico" type="image/png">
 
 </head>


### PR DESCRIPTION
The favicon files exist in `img\favicons`, but are missing from the header for `index.html` and `voter.html`.

This change allows the favicon to be rendered when bookmarking a page on Android to the "home screen", instead of just a generic "letter" icon.