### PR TITLE
Fix voter RSSI display on mobile screens

### DIFF
--- a/web/css/main.css
+++ b/web/css/main.css
@@ -224,3 +224,16 @@ body {
 }
 
 
+/*** Voter RSSI Display ***/
+/* On mobile, the default two-column layout (label left, bar right) causes
+ * label text to be cut off on narrow screens. Stack the label above the bar
+ * instead, matching Bootstrap's md breakpoint at 768px. */
+@media (max-width: 767.98px) {
+    #asl-votermon-area .col-4 {
+        width: 100% !important;
+        text-align: left !important;
+    }
+    #asl-votermon-area .col-8 {
+        width: 100% !important;
+    }
+}


### PR DESCRIPTION
## Problem

On mobile/narrow screens, the voter RSSI display uses a two-column Bootstrap layout (`col-4` label + `col-8` bar). The label column is only 33% of the row width, which causes longer receiver names to be cut off or wrapped awkwardly. The bar is also constrained to 67% of the available width on mobile, making it harder to read signal levels at a glance.

This was originally raised in #302, which was closed by pointing users to `custom.css` as a workaround. However, the layout issue exists regardless of customization and affects all users on mobile devices.

## Fix

Added a `@media (max-width: 767.98px)` block to `main.css` that stacks the label above the bar on mobile screens. Both elements expand to full row width, labels are left-aligned, and the bar uses the full available width.

On desktop (≥768px) the existing two-column layout is completely unchanged.

```css
@media (max-width: 767.98px) {
    #asl-votermon-area .col-4 {
        width: 100% !important;
        text-align: left !important;
    }
    #asl-votermon-area .col-8 {
        width: 100% !important;
    }
}
```

The breakpoint matches Bootstrap's `md` threshold exactly, so behavior is consistent with the rest of the Bootstrap grid used throughout Allmon3.

## Changes

- `web/css/main.css` — added voter mobile responsive block at end of file

No JavaScript changes. No backend changes. No effect on desktop layout.

See also: #302